### PR TITLE
Added decay.tar.gz and instructions on how to get it

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -14,3 +14,16 @@ This repository aims to store all data pertinent during an
 installation of PyNE. If features are added to PyNE that
 rely upon static data items, such as decay.tar.gz, they
 should be added to this repository
+
+decay.tar.gz
+============
+To produce the decay.tar.gz run the following command from the
+PyNE /src directory
+::
+   python decaygen.py
+   
+Then tar up the decay.cpp and decay.h files
+::
+   tar -pczf decay.tar.gz decay.cpp decay.h
+  
+Then add and commit them to this repository


### PR DESCRIPTION
This PR adds hosting of the files needed for PyNE installation on Github. Currently another PyNE PR will depend upon it, so this PR should be merged first, then the other PyNE PR can proceed.